### PR TITLE
Pre-fetch responses for spotify endpoints

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    kotlin("jvm") version "1.9.25"
-    kotlin("plugin.spring") version "1.9.25"
+    kotlin("jvm") version "2.1.20"
+    kotlin("plugin.spring") version "2.1.20"
     id("org.springframework.boot") version "3.4.4"
     id("io.spring.dependency-management") version "1.1.7"
 }

--- a/src/main/kotlin/xyz/colmmurphy/colmmurphyxyzbackend/ColmmurphyxyzBackendApplication.kt
+++ b/src/main/kotlin/xyz/colmmurphy/colmmurphyxyzbackend/ColmmurphyxyzBackendApplication.kt
@@ -2,6 +2,7 @@ package xyz.colmmurphy.colmmurphyxyzbackend
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableScheduling
 
@@ -10,6 +11,7 @@ class ColmmurphyxyzBackendApplication
 
 @Configuration
 @EnableScheduling
+@EnableCaching
 class SpringConfig
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/xyz/colmmurphy/colmmurphyxyzbackend/ColmmurphyxyzBackendApplication.kt
+++ b/src/main/kotlin/xyz/colmmurphy/colmmurphyxyzbackend/ColmmurphyxyzBackendApplication.kt
@@ -2,9 +2,15 @@ package xyz.colmmurphy.colmmurphyxyzbackend
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 class ColmmurphyxyzBackendApplication
+
+@Configuration
+@EnableScheduling
+class SpringConfig
 
 fun main(args: Array<String>) {
     runApplication<ColmmurphyxyzBackendApplication>(*args)

--- a/src/main/kotlin/xyz/colmmurphy/colmmurphyxyzbackend/spotify/ISpotifyService.kt
+++ b/src/main/kotlin/xyz/colmmurphy/colmmurphyxyzbackend/spotify/ISpotifyService.kt
@@ -5,7 +5,6 @@ import com.adamratzman.spotify.models.Track
 interface ISpotifyService {
     suspend fun createClientApi(authCode: String): Result<String>
     fun getStatus(): SpotifyStatusResponseEntity
-    suspend fun getTopTracks(): List<String>
     suspend fun getRecentTracks(limit: Int): List<PlayHistoryDto>
     suspend fun getCurrentlyPlayingTrack(): TrackDto?
 }

--- a/src/main/kotlin/xyz/colmmurphy/colmmurphyxyzbackend/spotify/SpotifyController.kt
+++ b/src/main/kotlin/xyz/colmmurphy/colmmurphyxyzbackend/spotify/SpotifyController.kt
@@ -72,16 +72,17 @@ class SpotifyController(
 
     @GetMapping("/api/spotify/recenttracks")
     suspend fun getRecentTracks(@RequestParam("limit") limit: Int): ResponseEntity<List<PlayHistoryDto>> {
-        val responseEntity = ResponseEntity
+        val cache = cachedRecentTracks
+        return ResponseEntity
             .ok()
             .cacheControl(CacheControl.maxAge(1, TimeUnit.MINUTES))
-        val cache = cachedRecentTracks
-        if (cache == null || limit > cache.size) {
-            responseEntity.body(service.getRecentTracks(limit))
-        } else {
-            responseEntity.body(cache.slice(0 until limit))
-        }
-        return responseEntity.build()
+            .body(
+                if (cache == null || limit > cache.size) {
+                    service.getRecentTracks(limit)
+                } else {
+                    cache.slice(0 until limit)
+                }
+            )
     }
 
     @GetMapping("/api/spotify/currentlyplaying")

--- a/src/main/kotlin/xyz/colmmurphy/colmmurphyxyzbackend/spotify/SpotifyController.kt
+++ b/src/main/kotlin/xyz/colmmurphy/colmmurphyxyzbackend/spotify/SpotifyController.kt
@@ -2,12 +2,14 @@ package xyz.colmmurphy.colmmurphyxyzbackend.spotify
 
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.CacheControl
 import org.springframework.http.ResponseEntity
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.util.concurrent.TimeUnit
 
 @CrossOrigin(origins = ["*"])
 @RestController
@@ -61,15 +63,23 @@ class SpotifyController(
     suspend fun getRecentTracks(@RequestParam("limit") limit: Int): ResponseEntity<List<PlayHistoryDto>> {
         if (limit == 10 && cachedTenRecentTracks != null) {
             log.info("Returning cached value for /recenttracks")
-            return ResponseEntity.ok(cachedTenRecentTracks)
+            return ResponseEntity
+                .ok()
+                .cacheControl(CacheControl.maxAge(1, TimeUnit.MINUTES))
+                .body(cachedTenRecentTracks)
         }
-        // fall back if no cached value
         val tracks = service.getRecentTracks(limit)
-        return ResponseEntity.ok(tracks)
+        return ResponseEntity
+            .ok()
+            .cacheControl(CacheControl.maxAge(1, TimeUnit.MINUTES))
+            .body(tracks)
     }
 
     @GetMapping("/api/spotify/currentlyplaying")
     suspend fun getCurrentlyPlayingTrack(): ResponseEntity<TrackDto?> {
-        return ResponseEntity.ok(cachedCurrentlyPlayingTrack)
+        return ResponseEntity
+            .ok()
+            .cacheControl(CacheControl.maxAge(1, TimeUnit.MINUTES))
+            .body(cachedCurrentlyPlayingTrack)
     }
 }

--- a/src/main/kotlin/xyz/colmmurphy/colmmurphyxyzbackend/spotify/SpotifyController.kt
+++ b/src/main/kotlin/xyz/colmmurphy/colmmurphyxyzbackend/spotify/SpotifyController.kt
@@ -19,7 +19,10 @@ class SpotifyController(
 ) {
     private val log = LoggerFactory.getLogger(this::class.java)
 
+    @Volatile
     private var cachedCurrentlyPlayingTrack: TrackDto? = null
+
+    @Volatile
     private var cachedRecentTracks: List<PlayHistoryDto>? = null
 
     @OptIn(DelicateCoroutinesApi::class)

--- a/src/main/kotlin/xyz/colmmurphy/colmmurphyxyzbackend/spotify/SpotifyController.kt
+++ b/src/main/kotlin/xyz/colmmurphy/colmmurphyxyzbackend/spotify/SpotifyController.kt
@@ -1,5 +1,6 @@
 package xyz.colmmurphy.colmmurphyxyzbackend.spotify
 
+import kotlinx.coroutines.*
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.CacheControl
@@ -21,21 +22,27 @@ class SpotifyController(
     private var cachedCurrentlyPlayingTrack: TrackDto? = null
     private var cachedRecentTracks: List<PlayHistoryDto>? = null
 
+    @OptIn(DelicateCoroutinesApi::class)
     @Scheduled(fixedRate = 2 * 60 * 1000, initialDelay = 60 * 1000)
-    protected suspend fun updateCurrentlyPlayingCache() {
-        cachedCurrentlyPlayingTrack = null
-        service.getCurrentlyPlayingTrack()?.let {
-            log.info("updated cached value for /currentlyplaying")
-            cachedCurrentlyPlayingTrack = it
+    protected fun updateCurrentlyPlayingCache() {
+        GlobalScope.launch(Dispatchers.IO) {
+            cachedCurrentlyPlayingTrack = null
+            service.getCurrentlyPlayingTrack()?.let {
+                log.info("updated cached value for /currentlyplaying")
+                cachedCurrentlyPlayingTrack = it
+            }
         }
     }
 
+    @OptIn(DelicateCoroutinesApi::class)
     @Scheduled(fixedRate = 2 * 60 * 1000, initialDelay = 60 * 1000)
-    protected suspend fun updateRecentTracks() {
-        cachedRecentTracks = null
-        val tracks = service.getRecentTracks(50)
-        cachedRecentTracks = tracks
-        log.info("Updated cached value for /recenttracks")
+    protected fun updateRecentTracks() {
+        GlobalScope.launch(Dispatchers.IO) {
+            cachedRecentTracks = null
+            val tracks = service.getRecentTracks(50)
+            cachedRecentTracks = tracks
+            log.info("Updated cached value for /recenttracks")
+        }
     }
 
     @GetMapping("/api/spotify/status")

--- a/src/main/kotlin/xyz/colmmurphy/colmmurphyxyzbackend/spotify/SpotifyController.kt
+++ b/src/main/kotlin/xyz/colmmurphy/colmmurphyxyzbackend/spotify/SpotifyController.kt
@@ -37,12 +37,6 @@ class SpotifyController(
         }
     }
 
-    @GetMapping("/api/spotify/toptracks")
-    suspend fun getTopTracks(): ResponseEntity<List<String>> {
-        val tracks = service.getTopTracks()
-        return ResponseEntity.ok(tracks)
-    }
-
     @GetMapping("/api/spotify/recenttracks")
     suspend fun getRecentTracks(@RequestParam("limit") limit: Int): ResponseEntity<List<PlayHistoryDto>> {
         val tracks = service.getRecentTracks(limit)

--- a/src/main/kotlin/xyz/colmmurphy/colmmurphyxyzbackend/spotify/SpotifyService.kt
+++ b/src/main/kotlin/xyz/colmmurphy/colmmurphyxyzbackend/spotify/SpotifyService.kt
@@ -5,6 +5,7 @@ import com.adamratzman.spotify.models.CurrentlyPlayingType
 import com.adamratzman.spotify.models.Track
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import xyz.colmmurphy.colmmurphyxyzbackend.AppConfiguration
 
@@ -25,6 +26,11 @@ class SpotifyService(private val appConfiguration: AppConfiguration) : ISpotifyS
         )
 
         log.info("Spotify auth URL: $url")
+    }
+
+    @Scheduled(fixedDelay = 1000)
+    private fun updateCache() {
+        foo += 1
     }
 
     override fun getStatus(): SpotifyStatusResponseEntity {
@@ -52,12 +58,6 @@ class SpotifyService(private val appConfiguration: AppConfiguration) : ISpotifyS
         ).build()
         log.info("Created spotify client")
         return Result.success("Created spotify client. Token expires in ${spotifyApi!!.token.expiresIn} seconds")
-    }
-
-    override suspend fun getTopTracks(): List<String> {
-        val foo = spotifyApi!!.personalization.getTopTracks(limit = 5).items.map { it.name }
-        log.info(foo.joinToString("\n"))
-        return foo
     }
 
     override suspend fun getRecentTracks(limit: Int): List<PlayHistoryDto> {

--- a/src/main/kotlin/xyz/colmmurphy/colmmurphyxyzbackend/spotify/SpotifyService.kt
+++ b/src/main/kotlin/xyz/colmmurphy/colmmurphyxyzbackend/spotify/SpotifyService.kt
@@ -5,7 +5,6 @@ import com.adamratzman.spotify.models.CurrentlyPlayingType
 import com.adamratzman.spotify.models.Track
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import xyz.colmmurphy.colmmurphyxyzbackend.AppConfiguration
 
@@ -26,11 +25,6 @@ class SpotifyService(private val appConfiguration: AppConfiguration) : ISpotifyS
         )
 
         log.info("Spotify auth URL: $url")
-    }
-
-    @Scheduled(fixedDelay = 1000)
-    private fun updateCache() {
-        foo += 1
     }
 
     override fun getStatus(): SpotifyStatusResponseEntity {


### PR DESCRIPTION
These endpoints can take ~500ms to fetch as-is. This change should greatly lessen that latency